### PR TITLE
rename GuestAddressValue to GuestUsize, not AddressValue + alignment fixes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -58,7 +58,7 @@ One of the main responsibilities of the GuestMemoryMmap object is to handle the 
 
 ### Utilities and Helpers
 Following utility and helper traits/macros are imported from the [crosvm project](https://chromium.googlesource.com/chromiumos/platform/crosvm/) with minor changes:
-- DataInit: Types for which it is safe to initialize from raw data. A type `T` is `DataInit` if and only if it can be initialized by reading its contents from a byte array. This is generally true for all plain-old-data structs.  It is notably not true for any type that includes a reference.
+- ByteValued (originally `DataInit`): Types for which it is safe to initialize from raw data. A type `T` is `ByteValued` if and only if it can be initialized by reading its contents from a byte array. This is generally true for all plain-old-data structs.  It is notably not true for any type that includes a reference.
 - {Le,Be}\_{16,32,64}: Explicit endian types useful for embedding in structs or reinterpreting data.
 
 ## Relationships between Traits, Structs and new Types

--- a/src/address.rs
+++ b/src/address.rs
@@ -11,17 +11,17 @@
 //! Traits to represent an address within an address space.
 //!
 //! Two traits are defined to present an address within an address space:
-//! - [GuestUsize](trait.GuestUsize.html): stores the raw value of an address. Typically u32,
+//! - [AddressValue](trait.AddressValue.html): stores the raw value of an address. Typically u32,
 //! u64 or usize is used to store the raw value. But pointers, such as *u8, can't be used because
 //! it doesn't implement the Add and Sub traits.
-//! - [Address](trait.Address.html): encapsulates an GuestUsize object and defines methods to
+//! - [Address](trait.Address.html): encapsulates an AddressValue object and defines methods to
 //! access and manipulate it.
 
 use std::cmp::{Eq, Ord, PartialEq, PartialOrd};
 use std::ops::{Add, BitAnd, BitOr, Sub};
 
 /// Simple helper trait used to store a raw address value.
-pub trait GuestUsize {
+pub trait AddressValue {
     /// Type of the address raw value.
     type V: Copy
         + PartialEq
@@ -36,7 +36,7 @@ pub trait GuestUsize {
 
 /// Trait to represent an address within an address space.
 ///
-/// To simplify the design and implementation, assume the same raw data type (GuestUsize::V)
+/// To simplify the design and implementation, assume the same raw data type (AddressValue::V)
 /// could be used to store address, size and offset for the address space. Thus the Address trait
 /// could be used to manage address, size and offset. On the other hand, type aliases may be
 /// defined to improve code readability.
@@ -44,9 +44,9 @@ pub trait GuestUsize {
 /// One design rule is applied to the Address trait that operators (+, -, &, | etc) are not
 /// supported and it forces clients to explicitly invoke corresponding methods. But there are
 /// always exceptions:
-///     Address (BitAnd|BitOr) GuestUsize are supported.
+///     Address (BitAnd|BitOr) AddressValue are supported.
 pub trait Address:
-    GuestUsize
+    AddressValue
     + Sized
     + Default
     + Copy
@@ -54,8 +54,8 @@ pub trait Address:
     + PartialEq
     + Ord
     + PartialOrd
-    + BitAnd<<Self as GuestUsize>::V, Output = Self>
-    + BitOr<<Self as GuestUsize>::V, Output = Self>
+    + BitAnd<<Self as AddressValue>::V, Output = Self>
+    + BitOr<<Self as AddressValue>::V, Output = Self>
 {
     /// Create an address from a raw address value.
     fn new(addr: Self::V) -> Self;
@@ -101,7 +101,7 @@ pub trait Address:
 
 macro_rules! impl_address_ops {
     ($T:ident, $V:ty) => {
-        impl GuestUsize for $T {
+        impl AddressValue for $T {
             type V = $V;
         }
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,3 +1,5 @@
+// Portions Copyright 2019 Red Hat, Inc.
+//
 // Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -32,7 +32,7 @@ use std::fmt::{self, Display};
 use std::io::{self, Read, Write};
 use std::ops::{BitAnd, BitOr};
 
-use address::{Address, GuestUsize};
+use address::{Address, AddressValue};
 use bytes::Bytes;
 use volatile_memory;
 
@@ -114,16 +114,13 @@ pub struct MemoryRegionAddress(pub u64);
 impl_address_ops!(MemoryRegionAddress, u64);
 
 /// Type of the raw value stored in a GuestAddress object.
-pub type GuestAddressValue = <GuestAddress as GuestUsize>::V;
-
-/// Type to encode offset in the guest physical address space.
-pub type GuestAddressOffset = <GuestAddress as GuestUsize>::V;
+pub type GuestUsize = <GuestAddress as AddressValue>::V;
 
 /// Represents a continuous region of guest physical memory.
 #[allow(clippy::len_without_is_empty)]
 pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     /// Get the size of the region.
-    fn len(&self) -> GuestAddressValue;
+    fn len(&self) -> GuestUsize;
 
     /// Get minimum (inclusive) address managed by the region.
     fn min_addr(&self) -> GuestAddress;
@@ -219,7 +216,7 @@ pub trait GuestMemory {
                     if total == count {
                         break;
                     }
-                    cur = match cur.overflowing_add(len as GuestAddressValue) {
+                    cur = match cur.overflowing_add(len as GuestUsize) {
                         (GuestAddress(0), _) => GuestAddress(0),
                         (result, false) => result,
                         (_, true) => panic!("guest address overflow"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ extern crate matches;
 
 #[macro_use]
 pub mod address;
-pub use address::{Address, GuestUsize};
+pub use address::{Address, AddressValue};
 
 pub mod bytes;
 pub use bytes::{ByteValued, Bytes};

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -341,8 +341,8 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
 }
 
 impl GuestMemoryRegion for GuestRegionMmap {
-    fn len(&self) -> GuestAddressValue {
-        self.mapping.len() as GuestAddressValue
+    fn len(&self) -> GuestUsize {
+        self.mapping.len() as GuestUsize
     }
 
     fn min_addr(&self) -> GuestAddress {
@@ -377,7 +377,7 @@ impl GuestMemoryMmap {
             if let Some(last) = regions.last() {
                 if last
                     .guest_base
-                    .checked_add(last.mapping.len() as GuestAddressValue)
+                    .checked_add(last.mapping.len() as GuestUsize)
                     .map_or(true, |a| a > range.0)
                 {
                     return Err(MmapError::MemoryRegionOverlap);
@@ -600,7 +600,7 @@ mod tests {
         let gm = GuestMemoryMmap::new(&regions).unwrap();
 
         let res: Result<()> = gm.with_regions(|_, region| {
-            assert_eq!(region.len(), region_size as GuestAddressValue);
+            assert_eq!(region.len(), region_size as GuestUsize);
             Ok(())
         });
         assert!(res.is_ok());

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -1,3 +1,5 @@
+// Portions Copyright 2019 Red Hat, Inc.
+//
 // Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRT-PARTY file.

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -119,9 +119,7 @@ pub trait VolatileMemory {
         unsafe {
             // This is safe because the pointer is range-checked by get_slice, and
             // the lifetime is the same as self.
-            //
-            // FIXME: should we check that offset is properly aligned?
-            Ok(VolatileRef::new(slice.addr as *mut T))
+            Ok(VolatileRef::<T>::new(slice.addr))
         }
     }
 
@@ -152,6 +150,9 @@ impl<'a> VolatileMemory for &'a mut [u8] {
         }
     }
 }
+
+#[repr(C, packed)]
+struct Packed<T>(T);
 
 /// A slice of raw memory that supports volatile access.
 #[derive(Copy, Clone, Debug)]
@@ -242,8 +243,7 @@ impl<'a> VolatileSlice<'a> {
         let mut i = 0;
         for v in buf.iter_mut().take(self.size / size_of::<T>()) {
             unsafe {
-                // FIXME: should we check that addr is correctly aligned?
-                *v = read_volatile(addr as *const T);
+                *v = read_volatile(addr as *const Packed<T>).0;
                 addr = addr.add(size_of::<T>());
             };
             i += 1;
@@ -308,8 +308,7 @@ impl<'a> VolatileSlice<'a> {
             unsafe {
                 // Safe because the pointers are range-checked when the slices
                 // are created, and they never escape the VolatileSlices.
-                // FIXME: should we check that addr is correctly aligned?
-                write_volatile(addr as *mut T, v);
+                write_volatile(addr as *mut Packed<T>, Packed::<T>(v));
                 addr = addr.add(size_of::<T>());
             }
         }
@@ -602,7 +601,7 @@ impl<'a> VolatileMemory for VolatileSlice<'a> {
 /// # use vm_memory::VolatileRef;
 ///   let mut v = 5u32;
 ///   assert_eq!(v, 5);
-///   let v_ref = unsafe { VolatileRef::new(&mut v as *mut u32) };
+///   let v_ref = unsafe { VolatileRef::<u32>::new(&mut v as *mut u32 as *mut u8) };
 ///   assert_eq!(v_ref.load(), 5);
 ///   v_ref.store(500);
 ///   assert_eq!(v, 500);
@@ -611,7 +610,7 @@ pub struct VolatileRef<'a, T: ByteValued>
 where
     T: 'a,
 {
-    addr: *mut T,
+    addr: *mut Packed<T>,
     phantom: PhantomData<&'a T>,
 }
 
@@ -623,16 +622,16 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
     /// `T` and is available for the duration of the lifetime of the new `VolatileRef`. The caller
     /// must also guarantee that all other users of the given chunk of memory are using volatile
     /// accesses.
-    pub unsafe fn new(addr: *mut T) -> VolatileRef<'a, T> {
+    pub unsafe fn new(addr: *mut u8) -> VolatileRef<'a, T> {
         VolatileRef {
-            addr,
+            addr: addr as *mut Packed<T>,
             phantom: PhantomData,
         }
     }
 
     /// Gets the address of this slice's memory.
-    pub fn as_ptr(&self) -> *mut T {
-        self.addr
+    pub fn as_ptr(&self) -> *mut u8 {
+        self.addr as *mut u8
     }
 
     /// Gets the size of this slice.
@@ -642,7 +641,7 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
     /// ```
     /// # use std::mem::size_of;
     /// # use vm_memory::VolatileRef;
-    ///   let v_ref = unsafe { VolatileRef::new(0 as *mut u32) };
+    ///   let v_ref = unsafe { VolatileRef::<u32>::new(0 as *mut _) };
     ///   assert_eq!(v_ref.len(), size_of::<u32>() as usize);
     /// ```
     pub fn len(&self) -> usize {
@@ -652,7 +651,7 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
     /// Does a volatile write of the value `v` to the address of this ref.
     #[inline(always)]
     pub fn store(&self, v: T) {
-        unsafe { write_volatile(self.addr, v) };
+        unsafe { write_volatile(self.addr, Packed::<T>(v)) };
     }
 
     /// Does a volatile read of the value at the address of this ref.
@@ -661,7 +660,7 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
         // For the purposes of demonstrating why read_volatile is necessary, try replacing the code
         // in this function with the commented code below and running `cargo test --release`.
         // unsafe { *(self.addr as *const T) }
-        unsafe { read_volatile(self.addr) }
+        unsafe { read_volatile(self.addr).0 }
     }
 
     /// Converts this `T` reference to a raw slice with the same size and address.
@@ -933,5 +932,21 @@ mod tests {
             .is_err());
         format!("{:?}", s.write_all_to(2, &mut sink, size_of::<u32>()));
         assert_eq!(sink, vec![0; size_of::<u32>()]);
+    }
+
+    #[test]
+    fn unaligned_read_and_write() {
+        let a = VecMem::new(7);
+        let s = a.as_volatile_slice();
+        let sample_buf: [u8; 7] = [1, 2, 0xAA, 0xAA, 0xAA, 0xAA, 4];
+        assert!(s.write_slice(&sample_buf, 0).is_ok());
+        let r = a.get_ref::<u32>(2).unwrap();
+        assert_eq!(r.load(), 0xAAAA_AAAA);
+
+        r.store(0x5555_5555);
+        let sample_buf: [u8; 7] = [1, 2, 0x55, 0x55, 0x55, 0x55, 4];
+        let mut buf: [u8;7] = Default::default();
+        assert!(s.read_slice(&mut buf, 0).is_ok());
+        assert_eq!(buf, sample_buf);
     }
 }


### PR DESCRIPTION
Just a small nit.